### PR TITLE
Feature: Add Volume Control to AudioEditor Preview and Save

### DIFF
--- a/Assets/Editor/Audio/AudioEditor.cs
+++ b/Assets/Editor/Audio/AudioEditor.cs
@@ -11,6 +11,7 @@ namespace SimblendTools
         private bool isAudioAdded = false;
 
         private AudioClip audioClip;
+        private float volume = 1f;
         private float startTrim = 0f;
         private float endTrim = 0f;
         private float fadeStartDuration = 0f;
@@ -84,6 +85,9 @@ namespace SimblendTools
                 fadeEndDuration = EditorGUILayout.Slider("Fade End Duration", fadeEndDuration, 0f, endTrim - startTrim);
                 loopPreview = GUILayout.Toggle(loopPreview, "Loop Preview");
 
+                // Volume slider
+                volume = EditorGUILayout.Slider("Volume", volume, 0f, 2f);
+                previewAudioSource.volume = volume;
 
                 // Update waveform texture when sliders or fade values are adjusted
                 if (GUI.changed)
@@ -144,6 +148,7 @@ namespace SimblendTools
             AudioClip trimmedClip = AudioClip.Create("TrimmedClip", trimmedSamples.Length, audioClip.channels, audioClip.frequency, false);
             trimmedClip.SetData(trimmedSamples, 0);
             previewAudioSource.loop = loopPreview; // Add looping control
+            previewAudioSource.volume = volume; // Add volume control
             previewAudioSource.clip = trimmedClip;
             previewAudioSource.Play();
 
@@ -344,6 +349,12 @@ namespace SimblendTools
                     // Apply fade-out to the end of the trimmed data
                     trimmedData[fadeOutStart + i] *= fadeFactor;
                 }
+            }
+
+            // Apply global volume scaling to the trimmed data
+            for (int i = 0; i < trimmedData.Length; i++)
+            {
+                trimmedData[i] *= volume;
             }
 
             AudioClip newClip = AudioClip.Create(clip.name + "_EDITED", trimmedData.Length / clip.channels, clip.channels, clip.frequency, false);


### PR DESCRIPTION
**Summary**

This pull request adds volume control functionality to the AudioEditor tool, allowing users to adjust the playback and export volume of audio clips directly within the Unity Editor.

**Key Changes**

✅ Added a Volume slider to control preview playback volume in real time.
✅ Applied the same volume scaling to the final saved audio clip.

**Motivation**

Previously, the AudioEditor allowed trimming and fading but didn’t let users control overall sound volume.
This enhancement improves usability by providing direct volume adjustment during preview and ensuring consistency between what is heard in the editor and the exported audio file.